### PR TITLE
[WIP] Add alternative set of Dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,97 @@
+VERSION         ?= $(shell git rev-parse --short HEAD)
+IMAGE_REGISTRY  ?= docker.io
+IMAGE_REPO      ?= $(IMAGE_REGISTRY)/diambra
+NVIDIA_REGISTRY ?= $(IMAGE_REGISTRY)
+UBUNTU_REGISTRY ?= $(IMAGE_REGISTRY)
+DOCKER          ?= docker
+CUDA_VERSION    ?= 11.5.0
+UBUNTU_VERSION  ?= 20.04
+
+# Only used in info ouput
+ROM_PATH        ?= ../diambraArena-roms/
+
+
+# Images to build base image from
+UBUNTU_BASE_IMAGE := $(UBUNTU_REGISTRY)/library/ubuntu:$(UBUNTU_VERSION)
+CUDA_BASE_IMAGE   := $(NVIDIA_REGISTRY)/nvidia/cuda:$(CUDA_VERSION)-runtime-ubuntu$(UBUNTU_VERSION)
+
+# Base image names
+BASE_IMAGE      := $(IMAGE_REPO)/base:$(VERSION)
+BASE_IMAGE_CUDA := $(IMAGE_REPO)/base-cuda:$(VERSION)
+
+# Final image names
+IMAGE      := $(IMAGE_REPO)/arena:$(VERSION)
+IMAGE_CUDA := $(IMAGE_REPO)/arena-cuda:$(VERSION)
+
+
+DIAMBRA_CRED_PATH := ${HOME}/.diambraCred
+CONTAINER_ARGS := \
+  -v $(ROM_PATH):/roms:ro \\\n\
+	-v ${HOME}/.diambraCred:/root/.diambraCred \\\n
+
+CONTAINER_ARGS_X := $(CONTAINER_ARGS) \
+	-v /tmp/.X11-unix:/tmp/.X11-unix \\\n \
+	-h $(shell hostname) -e DISPLAY=${DISPLAY} \\\n
+
+
+define INFO
+Available images:
+
+# CPU only
+## Headless
+$(DOCKER) run $(CONTAINER_ARGS) $(IMAGE) python examples/diambraArenaGist.py
+
+## with X
+$(DOCKER) run $(CONTAINER_ARGS_X) $(IMAGE) python examples/diambraArenaGist.py
+
+# NVIDIA CUDA
+## Headless
+$(DOCKER) run $(CONTAINER_ARGS) $(IMAGE_CUDA) python examples/diambraArenaGist.py
+
+## Cuda
+$(DOCKER) run $(CONTAINER_ARGS_X) $(IMAGE_CUDA) python examples/diambraArenaGist.py
+
+endef
+
+define build_image
+$(DOCKER) build -f $(1) -t $(2) --build-arg BASE_IMAGE=$(3) .
+endef
+
+.PHONY: all
+all: info
+
+export INFO
+info:
+	@echo "$$INFO"
+
+.PHONY: options
+options:
+	grep '^[A-Z_ ]*?' $(lastword $(MAKEFILE_LIST))
+
+.PHONY: images
+images: image image-cuda
+
+.PHONY: push-images
+push-images: images
+	$(DOCKER) push $(BASE_IMAGE)
+	$(DOCKER) push $(BASE_IMAGE_CUDA)
+	$(DOCKER) push $(IMAGE)
+	$(DOCKER) push $(IMAGE_CUDA)
+
+# Base Images
+.PHONY: image-base
+image-base:
+	$(call build_image,docker/Dockerfile.base,$(BASE_IMAGE),$(UBUNTU_BASE_IMAGE))
+
+.PHONY: image-base-cuda
+image-base-cuda: image-base
+	$(call build_image,docker/Dockerfile.base,$(BASE_IMAGE_CUDA),$(CUDA_BASE_IMAGE))
+
+# Final Images
+.PHONY: image
+image: image-base
+	$(call build_image,docker/Dockerfile,$(IMAGE),$(BASE_IMAGE))
+
+.PHONY: image-cuda
+image-cuda: image-base-cuda
+	$(call build_image,docker/Dockerfile,$(IMAGE_CUDA),$(BASE_IMAGE_CUDA))

--- a/cli/cmd/diambra/main.go
+++ b/cli/cmd/diambra/main.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"os"
+
+	"github.com/diambra/diambraArena/cli/commands"
+
+	"github.com/urfave/cli/v2"
+)
+
+func main() {
+	app := &cli.App{
+		Name: "diambra",
+		Commands: []*cli.Command{
+			{
+				Name:   "run",
+				Action: commands.Run,
+			},
+		},
+	}
+	app.Run(os.Args)
+}

--- a/cli/commands/run.go
+++ b/cli/commands/run.go
@@ -1,0 +1,7 @@
+package commands
+
+import "github.com/urfave/cli/v2"
+
+func Run(c *cli.Context) error {
+	return nil
+}

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -1,0 +1,10 @@
+module github.com/diambra/diambraArena/cli
+
+go 1.17
+
+require (
+	github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d // indirect
+	github.com/russross/blackfriday/v2 v2.0.1 // indirect
+	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
+	github.com/urfave/cli/v2 v2.3.0 // indirect
+)

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -1,0 +1,12 @@
+github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
+github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
+github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
+github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
+github.com/urfave/cli/v2 v2.3.0 h1:qph92Y649prgesehzOrQjdWyxFOp/QVM+6imKHad91M=
+github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,8 @@
+ARG BASE_IMAGE=diambra/base-x:latest
+FROM $BASE_IMAGE
+
+WORKDIR /opt/diambraArena/
+COPY .  /opt/diambraArena
+RUN pip install .
+
+ENV DIAMBRAROMSPATH="/roms/"

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -1,0 +1,16 @@
+# Create DIAMBRA Arena base image (diambra:diambra-arena-base)
+ARG BASE_IMAGE=ubuntu:20.04
+FROM $BASE_IMAGE
+
+# Maintainer
+LABEL maintainer="DIAMBRA Team <info@diambra.ai>"
+
+RUN printf 'APT::Install-Recommends "0";\nAPT::Install-Suggests "0";\n' > /etc/apt/apt.conf.d/99norecommend && \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get -qy install -qy gnupg2 curl wget ca-certificates build-essential \
+      libfreetype6-dev libhdf5-serial-dev libzmq3-dev pkg-config software-properties-common unzip \
+      python3-pip python3-tk libopencv-dev libboost-filesystem1.71.0 xvfb libsdl2-2.0-0 libsdl2-ttf-2.0-0 \
+      libqt5core5a libqt5widgets5 libqt5gui5 && \
+      apt-get clean && \
+      rm -rf /var/lib/apt/lists/* && \
+      ln -s python3 /usr/bin/python

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,28 @@
+# DiambraArena Container Images
+- to build all images, run `make images`
+- to push images, run `make push-images`
+
+You can use a custom registries to pull base images and push final images to. To
+see available options, run `make options`.
+
+Run `make info` to see how to run the images.
+
+
+## Image Hierarchy
+````
+ [ubuntu] [nvidia/cuda]
+      \        /
+       \      /
+  <Dockerfile.base>
+       /     \
+   [base]  [base-cuda]
+       \     /
+     <Dockerfile>
+       /     \
+      /       \
+  [arena]  [arena-cuda]
+
+
+[] Image
+<> Dockerfile
+```


### PR DESCRIPTION
- Optimized for smaller images and better cache utilization
- They are using the upstream cuda images provided by nvidia which should make maintaining these easier
- They add the code after installing the base dependencies for faster rebuilds
- Makefile to build them while supporting different container runtime (e.g podman) and custom registries

They are not yet used in the diambraArena.sh/bat scripts though. Will look into that next. Though I feel like they could be simplified as well.